### PR TITLE
Fix StackMapTable attributes in JAR files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ local.properties
 # Ignore Gradle build output directory
 build
 
+# Cursor, VSCode
+.history

--- a/inspector/src/main/kotlin/inspector/util/PackageTools.kt
+++ b/inspector/src/main/kotlin/inspector/util/PackageTools.kt
@@ -89,29 +89,30 @@ object PackageTools {
      */
     private fun fixJarStackMaps(jarFile: File) {
         val fixedJar = File(jarFile.parent, "${jarFile.nameWithoutExtension}_fixed.jar")
-        JarFile(jarFile).use { jar ->
-            JarOutputStream(FileOutputStream(fixedJar)).use { jos ->
-                jar.entries().asSequence().forEach { entry ->
-                    if (entry.isDirectory) return@forEach
-
-                    jos.putNextEntry(JarEntry(entry.name))
-                    jar.getInputStream(entry).use { input ->
-                        val bytes = input.readBytes()
-                        val fixed =
-                            if (entry.name.endsWith(".class")) {
-                                fixClassStackMaps(bytes)
-                            } else {
-                                bytes
+        try {
+            JarFile(jarFile).use { jar ->
+                JarOutputStream(FileOutputStream(fixedJar)).use { jos ->
+                    jar.entries().asSequence().forEach { entry ->
+                        jos.putNextEntry(JarEntry(entry.name))
+                        if (!entry.isDirectory) {
+                            jar.getInputStream(entry).use { input ->
+                                if (entry.name.endsWith(".class")) {
+                                    jos.write(fixClassStackMaps(input.readBytes()))
+                                } else {
+                                    input.copyTo(jos)
+                                }
                             }
-                        jos.write(fixed)
+                        }
+                        jos.closeEntry()
                     }
-                    jos.closeEntry()
                 }
             }
+            Files.move(fixedJar.toPath(), jarFile.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+        } finally {
+            if (fixedJar.exists()) {
+                fixedJar.delete()
+            }
         }
-
-        jarFile.delete()
-        fixedJar.renameTo(jarFile)
     }
 
     private fun fixClassStackMaps(classBytes: ByteArray): ByteArray {

--- a/inspector/src/main/kotlin/inspector/util/PackageTools.kt
+++ b/inspector/src/main/kotlin/inspector/util/PackageTools.kt
@@ -123,7 +123,8 @@ object PackageTools {
                     type2: String,
                 ): String = "java/lang/Object"
             }
-        reader.accept(writer, 0)
+        // Use SKIP_FRAMES to avoid mixing existing (possibly invalid) frames with recomputed ones
+        reader.accept(writer, ClassReader.SKIP_FRAMES)
         return writer.toByteArray()
     }
 

--- a/inspector/src/main/kotlin/inspector/util/PackageTools.kt
+++ b/inspector/src/main/kotlin/inspector/util/PackageTools.kt
@@ -80,7 +80,13 @@ object PackageTools {
             handler.dump(errorFile, emptyArray<String>())
         }
 
-        fixJarStackMaps(jarFile)
+        if (jarFile.exists() && jarFile.length() > 0L) {
+            runCatching {
+                fixJarStackMaps(jarFile)
+            }.onFailure { error ->
+                logger.warn(error) { "Failed to fix stack maps for generated jar: ${jarFile.absolutePath}" }
+            }
+        }
     }
 
     /**

--- a/inspector/src/main/kotlin/inspector/util/PackageTools.kt
+++ b/inspector/src/main/kotlin/inspector/util/PackageTools.kt
@@ -16,13 +16,19 @@ import com.googlecode.dex2jar.tools.BaksmaliBaseDexExceptionHandler
 import io.github.oshai.kotlinlogging.KotlinLogging
 import net.dongliu.apk.parser.ApkFile
 import net.dongliu.apk.parser.ApkParsers
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassWriter
 import org.w3c.dom.Element
 import org.w3c.dom.Node
 import xyz.nulldev.androidcompat.pm.InstalledPackage.Companion.toList
 import xyz.nulldev.androidcompat.pm.toPackageInfo
 import java.io.File
+import java.io.FileOutputStream
 import java.net.URLClassLoader
 import java.nio.file.Files
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
+import java.util.jar.JarOutputStream
 import javax.xml.parsers.DocumentBuilderFactory
 
 object PackageTools {
@@ -73,6 +79,52 @@ object PackageTools {
             }
             handler.dump(errorFile, emptyArray<String>())
         }
+
+        fixJarStackMaps(jarFile)
+    }
+
+    /**
+     * dex2jar output often lacks valid StackMapTable attributes, which makes the JVM
+     * reject extension classes built with newer Android toolchains (e.g. minSdk 24).
+     */
+    private fun fixJarStackMaps(jarFile: File) {
+        val fixedJar = File(jarFile.parent, "${jarFile.nameWithoutExtension}_fixed.jar")
+        JarFile(jarFile).use { jar ->
+            JarOutputStream(FileOutputStream(fixedJar)).use { jos ->
+                jar.entries().asSequence().forEach { entry ->
+                    if (entry.isDirectory) return@forEach
+
+                    jos.putNextEntry(JarEntry(entry.name))
+                    jar.getInputStream(entry).use { input ->
+                        val bytes = input.readBytes()
+                        val fixed =
+                            if (entry.name.endsWith(".class")) {
+                                fixClassStackMaps(bytes)
+                            } else {
+                                bytes
+                            }
+                        jos.write(fixed)
+                    }
+                    jos.closeEntry()
+                }
+            }
+        }
+
+        jarFile.delete()
+        fixedJar.renameTo(jarFile)
+    }
+
+    private fun fixClassStackMaps(classBytes: ByteArray): ByteArray {
+        val reader = ClassReader(classBytes)
+        val writer =
+            object : ClassWriter(ClassWriter.COMPUTE_FRAMES) {
+                override fun getCommonSuperClass(
+                    type1: String,
+                    type2: String,
+                ): String = "java/lang/Object"
+            }
+        reader.accept(writer, 0)
+        return writer.toByteArray()
     }
 
     /** A modified version of `xyz.nulldev.androidcompat.pm.InstalledPackage.info` */


### PR DESCRIPTION
Implemented a new method in PackageTools to address issues with StackMapTable attributes in dex2jar outputs. This enhancement ensures compatibility with newer Android toolchains by creating a fixed JAR file with corrected class files. The original JAR is replaced with the fixed version after processing.

- Added fixJarStackMaps and fixClassStackMaps methods
- Utilized ClassReader and ClassWriter from ASM for bytecode manipulation

## Summary by Sourcery

Post-process dex2jar-generated JARs to rebuild class StackMapTable frames for JVM compatibility.

Bug Fixes:
- Rewrite dex2jar output JARs to include valid StackMapTable attributes so extension classes run on newer JVMs.

Enhancements:
- Add ASM-based utilities to recompute stack maps for each class file within generated JARs.